### PR TITLE
Core key reorganization

### DIFF
--- a/js/forum/src/components/AvatarEditor.js
+++ b/js/forum/src/components/AvatarEditor.js
@@ -62,7 +62,7 @@ export default class AvatarEditor extends Component {
     items.add('upload',
       Button.component({
         icon: 'upload',
-        children: app.trans('core.upload'),
+        children: app.trans('core.user_avatar_upload_button'),
         onclick: this.upload.bind(this)
       })
     );
@@ -70,7 +70,7 @@ export default class AvatarEditor extends Component {
     items.add('remove',
       Button.component({
         icon: 'times',
-        children: app.trans('core.remove'),
+        children: app.trans('core.user_avatar_remove_button'),
         onclick: this.remove.bind(this)
       })
     );

--- a/js/forum/src/components/ChangeEmailModal.js
+++ b/js/forum/src/components/ChangeEmailModal.js
@@ -29,7 +29,7 @@ export default class ChangeEmailModal extends Modal {
   }
 
   title() {
-    return app.trans('core.change_email');
+    return app.trans('core.change_email_title');
   }
 
   content() {
@@ -39,10 +39,11 @@ export default class ChangeEmailModal extends Modal {
       return (
         <div className="Modal-body">
           <div className="Form Form--centered">
-            <p className="helpText">{app.trans('core.confirmation_email_sent', {email: <strong>{this.email()}</strong>})}</p>
+            <p className="helpText">{app.trans('core.change_email_confirmation_message', {email: <strong>{this.email()}</strong>})}</p>
             <div className="Form-group">
+              // Core Key Reorganization: This needs to be changed to a dismiss button!
               <a href={'http://' + emailProviderName} className="Button Button--primary Button--block">
-                {app.trans('core.go_to', {location: emailProviderName})}
+                {app.trans('core.change_email_dismiss_button', {location: emailProviderName})}
               </a>
             </div>
           </div>
@@ -65,7 +66,7 @@ export default class ChangeEmailModal extends Modal {
               className: 'Button Button--primary Button--block',
               type: 'submit',
               loading: this.loading,
-              children: app.trans('core.save_changes')
+              children: app.trans('core.change_email_submit_button')
             })}
           </div>
         </div>

--- a/js/forum/src/components/ChangePasswordModal.js
+++ b/js/forum/src/components/ChangePasswordModal.js
@@ -11,20 +11,20 @@ export default class ChangePasswordModal extends Modal {
   }
 
   title() {
-    return app.trans('core.change_password');
+    return app.trans('core.change_password_title');
   }
 
   content() {
     return (
       <div className="Modal-body">
         <div className="Form Form--centered">
-          <p className="helpText">{app.trans('core.change_password_help')}</p>
+          <p className="helpText">{app.trans('core.change_password_text')}</p>
           <div className="Form-group">
             {Button.component({
               className: 'Button Button--primary Button--block',
               type: 'submit',
               loading: this.loading,
-              children: app.trans('core.send_password_reset_email')
+              children: app.trans('core.change_password_send_button')
             })}
           </div>
         </div>

--- a/js/forum/src/components/Composer.js
+++ b/js/forum/src/components/Composer.js
@@ -460,28 +460,28 @@ class Composer extends Component {
     if (this.position === Composer.PositionEnum.FULLSCREEN) {
       items.add('exitFullScreen', ComposerButton.component({
         icon: 'compress',
-        title: app.trans('core.exit_full_screen'),
+        title: app.trans('core.composer_exit_full_screen_tooltip'),
         onclick: this.exitFullScreen.bind(this)
       }));
     } else {
       if (this.position !== Composer.PositionEnum.MINIMIZED) {
         items.add('minimize', ComposerButton.component({
           icon: 'minus minimize',
-          title: app.trans('core.minimize'),
+          title: app.trans('core.composer_minimize_tooltip'),
           onclick: this.minimize.bind(this),
           itemClassName: 'App-backControl'
         }));
 
         items.add('fullScreen', ComposerButton.component({
           icon: 'expand',
-          title: app.trans('core.full_screen'),
+          title: app.trans('core.composer_full_screen_tooltip'),
           onclick: this.fullScreen.bind(this)
         }));
       }
 
       items.add('close', ComposerButton.component({
         icon: 'times',
-        title: app.trans('core.close'),
+        title: app.trans('core.composer_close_tooltip'),
         onclick: this.close.bind(this)
       }));
     }

--- a/js/forum/src/components/DiscussionComposer.js
+++ b/js/forum/src/components/DiscussionComposer.js
@@ -26,10 +26,10 @@ export default class DiscussionComposer extends ComposerBody {
   static initProps(props) {
     super.initProps(props);
 
-    props.placeholder = props.placeholder || app.trans('core.write_a_post');
-    props.submitLabel = props.submitLabel || app.trans('core.post_discussion');
-    props.confirmExit = props.confirmExit || app.trans('core.confirm_discard_discussion');
-    props.titlePlaceholder = props.titlePlaceholder || app.trans('core.discussion_title');
+    props.placeholder = props.placeholder || app.trans('core.composer_discussion_body_placeholder');
+    props.submitLabel = props.submitLabel || app.trans('core.composer_discussion_submit_button');
+    props.confirmExit = props.confirmExit || app.trans('core.composer_discussion_discard_confirmation');
+    props.titlePlaceholder = props.titlePlaceholder || app.trans('core.composer_discussion_title_placeholder');
   }
 
   headerItems() {

--- a/js/forum/src/components/DiscussionList.js
+++ b/js/forum/src/components/DiscussionList.js
@@ -48,7 +48,7 @@ export default class DiscussionList extends Component {
       loading = LoadingIndicator.component();
     } else if (this.moreResults) {
       loading = Button.component({
-        children: app.trans('core.load_more'),
+        children: app.trans('core.discussion_list_load_more_button'),
         className: 'Button',
         onclick: this.loadMore.bind(this)
       });

--- a/js/forum/src/components/DiscussionListItem.js
+++ b/js/forum/src/components/DiscussionListItem.js
@@ -87,7 +87,7 @@ export default class DiscussionListItem extends Component {
         <div className={'DiscussionListItem-content Slidable-content' + (isUnread ? ' unread' : '') + (isRead ? ' read' : '')}>
           <a href={startUser ? app.route.user(startUser) : '#'}
             className="DiscussionListItem-author"
-            title={extractText(app.trans('core.discussion_started', {user: startUser, ago: humanTime(discussion.startTime())}))}
+            title={extractText(app.trans('core.discussion_list_started_text', {user: startUser, ago: humanTime(discussion.startTime())}))}
             config={function(element) {
               $(element).tooltip({placement: 'right'});
               m.route.apply(this, arguments);
@@ -108,7 +108,7 @@ export default class DiscussionListItem extends Component {
 
           <span className="DiscussionListItem-count"
             onclick={this.markAsRead.bind(this)}
-            title={showUnread ? app.trans('core.mark_as_read') : ''}>
+            title={showUnread ? app.trans('core.discussion_list_mark_as_read_tooltip') : ''}>
             {abbreviateNumber(discussion[showUnread ? 'unreadCount' : 'repliesCount']())}
           </span>
 

--- a/js/forum/src/components/DiscussionRenamedNotification.js
+++ b/js/forum/src/components/DiscussionRenamedNotification.js
@@ -20,6 +20,6 @@ export default class DiscussionRenamedNotification extends Notification {
   }
 
   content() {
-    return app.trans('core.discussion_renamed_notification', {user: this.props.notification.sender()});
+    return app.trans('core.notifications_discussion_renamed_text', {user: this.props.notification.sender()});
   }
 }

--- a/js/forum/src/components/DiscussionRenamedPost.js
+++ b/js/forum/src/components/DiscussionRenamedPost.js
@@ -14,7 +14,7 @@ export default class DiscussionRenamedPost extends EventPost {
   }
 
   descriptionKey() {
-    return 'core.discussion_renamed_post';
+    return 'core.post_stream_discussion_renamed_text';
   }
 
   descriptionData() {

--- a/js/forum/src/components/DiscussionsSearchSource.js
+++ b/js/forum/src/components/DiscussionsSearchSource.js
@@ -28,11 +28,11 @@ export default class DiscussionsSearchSource {
     const results = this.results[query] || [];
 
     return [
-      <li className="Dropdown-header">{app.trans('core.discussions')}</li>,
+      <li className="Dropdown-header">{app.trans('core.search_discussions_heading')}</li>,
       <li>
         {LinkButton.component({
           icon: 'search',
-          children: app.trans('core.search_all_discussions', {query}),
+          children: app.trans('core.search_all_discussions_button', {query}),
           href: app.route('index', {q: query})
         })}
       </li>,

--- a/js/forum/src/components/EditPostComposer.js
+++ b/js/forum/src/components/EditPostComposer.js
@@ -23,8 +23,8 @@ export default class EditPostComposer extends ComposerBody {
   static initProps(props) {
     super.initProps(props);
 
-    props.submitLabel = props.submitLabel || app.trans('core.save_changes');
-    props.confirmExit = props.confirmExit || app.trans('core.confirm_discard_edit');
+    props.submitLabel = props.submitLabel || app.trans('core.composer_edit_submit_button');
+    props.confirmExit = props.confirmExit || app.trans('core.composer_edit_discard_confirmation');
     props.originalContent = props.originalContent || props.post.content();
     props.user = props.user || props.post.user();
 
@@ -39,7 +39,7 @@ export default class EditPostComposer extends ComposerBody {
       <h3>
         {icon('pencil')}{' '}
         <a href={app.route.discussion(post.discussion(), post.number())} config={m.route}>
-          {app.trans('core.editing_post', {number: post.number(), discussion: post.discussion().title()})}
+          {app.trans('core.composer_edit_post_link', {number: post.number(), discussion: post.discussion().title()})}
         </a>
       </h3>
     ));

--- a/js/forum/src/components/EditUserModal.js
+++ b/js/forum/src/components/EditUserModal.js
@@ -37,7 +37,7 @@ export default class EditUserModal extends Modal {
         <div className="Form">
           <div className="Form-group">
             <label>Username</label>
-            <input className="FormControl" placeholder={app.trans('core.username')}
+            <input className="FormControl" placeholder={app.trans('core.edit_user_username_label')}
               value={this.username()}
               onchange={m.withAttr('value', this.username)} />
           </div>
@@ -45,7 +45,7 @@ export default class EditUserModal extends Modal {
           <div className="Form-group">
             <label>Email</label>
             <div>
-              <input className="FormControl" placeholder={app.trans('core.email')}
+              <input className="FormControl" placeholder={app.trans('core.edit_user_email_label')}
                 value={this.email()}
                 onchange={m.withAttr('value', this.email)} />
             </div>
@@ -64,7 +64,7 @@ export default class EditUserModal extends Modal {
                 Set new password
               </label>
               {this.setPassword() ? (
-                <input className="FormControl" type="password" name="password" placeholder={app.trans('core.password')}
+                <input className="FormControl" type="password" name="password" placeholder={app.trans('core.edit_user_password_label')}
                   value={this.password()}
                   onchange={m.withAttr('value', this.password)} />
               ) : ''}
@@ -93,7 +93,7 @@ export default class EditUserModal extends Modal {
               className: 'Button Button--primary',
               type: 'submit',
               loading: this.loading,
-              children: app.trans('core.save_changes')
+              children: app.trans('core.edit_user_submit_button')
             })}
           </div>
         </div>

--- a/js/forum/src/components/ForgotPasswordModal.js
+++ b/js/forum/src/components/ForgotPasswordModal.js
@@ -34,7 +34,7 @@ export default class ForgotPasswordModal extends Modal {
   }
 
   title() {
-    return app.trans('core.forgot_password');
+    return app.trans('core.forgot_password_title');
   }
 
   content() {
@@ -44,10 +44,11 @@ export default class ForgotPasswordModal extends Modal {
       return (
         <div className="Modal-body">
           <div className="Form Form--centered">
-            <p className="helpText">{app.trans('core.password_reset_email_sent')}</p>
+            <p className="helpText">{app.trans('core.forgot_password_email_sent_message')}</p>
             <div className="Form-group">
+              // Core Key Reorganization: This needs to be changed to a dismiss button!
               <a href={'http://' + emailProviderName} className="Button Button--primary Button--block">
-                {app.trans('core.go_to', {location: emailProviderName})}
+                {app.trans('core.forgot_password_dismiss_button', {location: emailProviderName})}
               </a>
             </div>
           </div>
@@ -58,9 +59,9 @@ export default class ForgotPasswordModal extends Modal {
     return (
       <div className="Modal-body">
         <div className="Form Form--centered">
-          <p className="helpText">{app.trans('core.forgot_password_help')}</p>
+          <p className="helpText">{app.trans('core.forgot_password_text')}</p>
           <div className="Form-group">
-            <input className="FormControl" name="email" type="email" placeholder={app.trans('core.email')}
+            <input className="FormControl" name="email" type="email" placeholder={app.trans('core.forgot_password_email_placeholder')}
               value={this.email()}
               onchange={m.withAttr('value', this.email)}
               disabled={this.loading} />
@@ -70,7 +71,7 @@ export default class ForgotPasswordModal extends Modal {
               className: 'Button Button--primary Button--block',
               type: 'submit',
               loading: this.loading,
-              children: app.trans('core.recover_password')
+              children: app.trans('core.forgot_password_submit_button')
             })}
           </div>
         </div>

--- a/js/forum/src/components/HeaderSecondary.js
+++ b/js/forum/src/components/HeaderSecondary.js
@@ -64,7 +64,7 @@ export default class HeaderSecondary extends Component {
       if (app.forum.attribute('allowSignUp')) {
         items.add('signUp',
           Button.component({
-            children: app.trans('core.sign_up'),
+            children: app.trans('core.header_sign_up_link'),
             className: 'Button Button--link',
             onclick: () => app.modal.show(new SignUpModal())
           }), 10
@@ -73,7 +73,7 @@ export default class HeaderSecondary extends Component {
 
       items.add('logIn',
         Button.component({
-          children: app.trans('core.log_in'),
+          children: app.trans('core.header_log_in_link'),
           className: 'Button Button--link',
           onclick: () => app.modal.show(new LogInModal())
         }), 0

--- a/js/forum/src/components/IndexPage.js
+++ b/js/forum/src/components/IndexPage.js
@@ -147,7 +147,8 @@ export default class IndexPage extends Page {
 
     items.add('newDiscussion',
       Button.component({
-        children: canStartDiscussion ? app.trans('core.start_a_discussion') : 'Can\'t Start Discussion',
+        // Core Key Reorganization: Extracted the "Can't Start Discussion" string
+        children: app.trans(canStartDiscussion ? 'core.index_start_discussion_button' : 'core.index_cannot_start_discussion_button'),
         icon: 'edit',
         className: 'Button Button--primary IndexPage-newDiscussion',
         itemClassName: 'App-primaryControl',
@@ -180,7 +181,7 @@ export default class IndexPage extends Page {
     items.add('allDiscussions',
       LinkButton.component({
         href: app.route('index', params),
-        children: app.trans('core.all_discussions'),
+        children: app.trans('core.index_all_discussions_link'),
         icon: 'comments-o'
       }),
       100
@@ -201,7 +202,8 @@ export default class IndexPage extends Page {
 
     const sortOptions = {};
     for (const i in app.cache.discussionList.sortMap()) {
-      sortOptions[i] = app.trans('core.sort_' + i);
+      // Core Key Reorganization: Adjusted syntax for new key names
+      sortOptions[i] = app.trans('core.index_sort_' + i + '_button');
     }
 
     items.add('sort',
@@ -226,7 +228,7 @@ export default class IndexPage extends Page {
 
     items.add('refresh',
       Button.component({
-        title: app.trans('core.refresh'),
+        title: app.trans('core.index_refresh_tooltip'),
         icon: 'refresh',
         className: 'Button Button--icon',
         onclick: () => app.cache.discussionList.refresh()
@@ -236,7 +238,7 @@ export default class IndexPage extends Page {
     if (app.session.user) {
       items.add('markAllAsRead',
         Button.component({
-          title: app.trans('core.mark_all_as_read'),
+          title: app.trans('core.index_mark_all_as_read_tooltip'),
           icon: 'check',
           className: 'Button Button--icon',
           onclick: this.markAllAsRead.bind(this)

--- a/js/forum/src/components/LogInModal.js
+++ b/js/forum/src/components/LogInModal.js
@@ -37,7 +37,7 @@ export default class LogInModal extends Modal {
   }
 
   title() {
-    return app.trans('core.log_in');
+    return app.trans('core.log_in_title');
   }
 
   content() {
@@ -47,14 +47,14 @@ export default class LogInModal extends Modal {
 
         <div className="Form Form--centered">
           <div className="Form-group">
-            <input className="FormControl" name="email" placeholder={app.trans('core.username_or_email')}
+            <input className="FormControl" name="email" placeholder={app.trans('core.log_in_username_or_email_placeholder')}
               value={this.email()}
               onchange={m.withAttr('value', this.email)}
               disabled={this.loading} />
           </div>
 
           <div className="Form-group">
-            <input className="FormControl" name="password" type="password" placeholder={app.trans('core.password')}
+            <input className="FormControl" name="password" type="password" placeholder={app.trans('core.log_in_password_placeholder')}
               value={this.password()}
               onchange={m.withAttr('value', this.password)}
               disabled={this.loading} />
@@ -65,20 +65,21 @@ export default class LogInModal extends Modal {
               className: 'Button Button--primary Button--block',
               type: 'submit',
               loading: this.loading,
-              children: app.trans('core.log_in')
+              children: app.trans('core.log_in_submit_button')
             })}
           </div>
         </div>
       </div>,
       <div className="Modal-footer">
         <p className="LogInModal-forgotPassword">
-          <a onclick={this.forgotPassword.bind(this)}>{app.trans('core.forgot_password_link')}</a>
+          <a onclick={this.forgotPassword.bind(this)}>{app.trans('core.log_in_forgot_password_link')}</a>
         </p>
 
         {app.forum.attribute('allowSignUp') ? (
           <p className="LogInModal-signUp">
-            {app.trans('core.before_sign_up_link')}{' '}
-            <a onclick={this.signUp.bind(this)}>{app.trans('core.sign_up')}</a>
+            // Core Key Reorganization: Moved hardcoded space into preceding string.
+            {app.trans('core.log_in_no_account_text')}
+            <a onclick={this.signUp.bind(this)}>{app.trans('core.log_in_sign_up_link')}</a>
           </p>
         ) : ''}
       </div>
@@ -131,12 +132,12 @@ export default class LogInModal extends Modal {
 
         if (response && response.code === 'confirm_email') {
           this.alert = Alert.component({
-            children: app.trans('core.email_confirmation_required', {email: response.email})
+            children: app.trans('core.log_in_confirmation_required_message', {email: response.email})
           });
         } else {
           this.alert = Alert.component({
             type: 'error',
-            children: app.trans('core.invalid_login')
+            children: app.trans('core.log_in_invalid_login_message')
           });
         }
 

--- a/js/forum/src/components/NotificationGrid.js
+++ b/js/forum/src/components/NotificationGrid.js
@@ -21,8 +21,8 @@ export default class NotificationGrid extends Component {
      * @type {Array}
      */
     this.methods = [
-      {name: 'alert', icon: 'bell', label: app.trans('core.alert')},
-      {name: 'email', icon: 'envelope-o', label: app.trans('core.email')}
+      {name: 'alert', icon: 'bell', label: app.trans('core.settings_notify_by_web_heading')},
+      {name: 'email', icon: 'envelope-o', label: app.trans('core.settings_notify_by_email_heading')}
     ];
 
     /**
@@ -182,7 +182,7 @@ export default class NotificationGrid extends Component {
     items.add('discussionRenamed', {
       name: 'discussionRenamed',
       icon: 'pencil',
-      label: app.trans('core.notify_discussion_renamed')
+      label: app.trans('core.settings_notify_discussion_renamed_label')
     });
 
     return items;

--- a/js/forum/src/components/NotificationList.js
+++ b/js/forum/src/components/NotificationList.js
@@ -59,12 +59,12 @@ export default class NotificationList extends Component {
             {Button.component({
               className: 'Button Button--icon Button--link',
               icon: 'check',
-              title: app.trans('core.mark_all_as_read'),
+              title: app.trans('core.notifications_mark_all_as_read_tooltip'),
               onclick: this.markAllAsRead.bind(this)
             })}
           </div>
 
-          <h4 className="App-titleControl App-titleControl--text">{app.trans('core.notifications')}</h4>
+          <h4 className="App-titleControl App-titleControl--text">{app.trans('core.notifications_title')}</h4>
         </div>
 
         <div className="NotificationList-content">
@@ -98,7 +98,7 @@ export default class NotificationList extends Component {
               );
             })
             : !this.loading
-              ? <div className="NotificationList-empty">{app.trans('core.no_notifications')}</div>
+              ? <div className="NotificationList-empty">{app.trans('core.notifications_empty_text')}</div>
               : LoadingIndicator.component({className: 'LoadingIndicator--block'})}
         </div>
       </div>

--- a/js/forum/src/components/NotificationsDropdown.js
+++ b/js/forum/src/components/NotificationsDropdown.js
@@ -7,7 +7,7 @@ export default class NotificationsDropdown extends Dropdown {
     props.className = props.className || 'NotificationsDropdown';
     props.buttonClassName = props.buttonClassName || 'Button Button--flat';
     props.menuClassName = props.menuClassName || 'Dropdown-menu--right';
-    props.label = props.label || app.trans('core.notifications');
+    props.label = props.label || app.trans('core.notifications_tooltip');
     props.icon = props.icon || 'bell';
 
     super.initProps(props);

--- a/js/forum/src/components/PostEdited.js
+++ b/js/forum/src/components/PostEdited.js
@@ -15,7 +15,7 @@ export default class PostEdited extends Component {
   view() {
     const post = this.props.post;
     const editUser = post.editUser();
-    const title = extractText(app.trans('core.post_edited', {user: editUser, ago: humanTime(post.editTime())}));
+    const title = extractText(app.trans('core.post_edited_tooltip', {user: editUser, ago: humanTime(post.editTime())}));
 
     return (
       <span className="PostEdited" title={title}>{icon('pencil')}</span>

--- a/js/forum/src/components/PostMeta.js
+++ b/js/forum/src/components/PostMeta.js
@@ -33,7 +33,7 @@ export default class PostMeta extends Component {
         </a>
 
         <div className="Dropdown-menu dropdown-menu">
-          <span className="PostMeta-number">{app.trans('core.post_number', {number: post.number()})}</span>{' '}
+          <span className="PostMeta-number">{app.trans('core.post_number_tooltip', {number: post.number()})}</span>{' '}
           {fullTime(time)}
           {touch
             ? <a className="Button PostMeta-permalink" href={permalink}>{permalink}</a>

--- a/js/forum/src/components/PostStream.js
+++ b/js/forum/src/components/PostStream.js
@@ -221,7 +221,7 @@ class PostStream extends mixin(Component, evented) {
             if (dt > 1000 * 60 * 60 * 24 * 4) {
               content = [
                 <div className="PostStream-timeGap">
-                  <span>{app.trans('core.period_later', {period: moment.duration(dt).humanize()})}</span>
+                  <span>{app.trans('core.post_stream_time_lapsed_text', {period: moment.duration(dt).humanize()})}</span>
                 </div>,
                 content
               ];

--- a/js/forum/src/components/PostStreamScrubber.js
+++ b/js/forum/src/components/PostStreamScrubber.js
@@ -71,7 +71,7 @@ export default class PostStreamScrubber extends Component {
     const unreadCount = this.props.stream.discussion.unreadCount();
     const unreadPercent = Math.min(this.count() - this.index, unreadCount) / this.count();
 
-    const viewing = app.trans('core.viewing_posts', {
+    const viewing = app.trans('core.post_scrubber_viewing_text', {
       index: <span className="Scrubber-index">{retain || formatNumber(this.visibleIndex())}</span>,
       count: <span className="Scrubber-count">{formatNumber(this.count())}</span>
     });
@@ -101,7 +101,7 @@ export default class PostStreamScrubber extends Component {
         <div className="Dropdown-menu dropdown-menu">
           <div className="Scrubber">
             <a className="Scrubber-first" onclick={this.goToFirst.bind(this)}>
-              {icon('angle-double-up')} {app.trans('core.original_post')}
+              {icon('angle-double-up')} {app.trans('core.post_scrubber_original_post_link')}
             </a>
 
             <div className="Scrubber-scrollbar">
@@ -116,12 +116,12 @@ export default class PostStreamScrubber extends Component {
               <div className="Scrubber-after"/>
 
               <div className="Scrubber-unread" config={styleUnread}>
-                {app.trans('core.unread_posts', {count: unreadCount})}
+                {app.trans('core.post_scrubber_unread_text', {count: unreadCount})}
               </div>
             </div>
 
             <a className="Scrubber-last" onclick={this.goToLast.bind(this)}>
-              {icon('angle-double-down')} {app.trans('core.now')}
+              {icon('angle-double-down')} {app.trans('core.post_scrubber_now_link')}
             </a>
           </div>
         </div>

--- a/js/forum/src/components/PostsUserPage.js
+++ b/js/forum/src/components/PostsUserPage.js
@@ -51,7 +51,7 @@ export default class PostsUserPage extends UserPage {
       footer = (
         <div className="PostsUserPage-loadMore">
           {Button.component({
-            children: app.trans('core.load_more'),
+            children: app.trans('core.user_posts_load_more_button'),
             className: 'Button',
             onclick: this.loadMore.bind(this)
           })}

--- a/js/forum/src/components/ReplyComposer.js
+++ b/js/forum/src/components/ReplyComposer.js
@@ -24,9 +24,9 @@ export default class ReplyComposer extends ComposerBody {
   static initProps(props) {
     super.initProps(props);
 
-    props.placeholder = props.placeholder || app.trans('core.write_a_reply');
-    props.submitLabel = props.submitLabel || app.trans('core.post_reply');
-    props.confirmExit = props.confirmExit || app.trans('core.confirm_discard_reply');
+    props.placeholder = props.placeholder || app.trans('core.composer_reply_body_placeholder');
+    props.submitLabel = props.submitLabel || app.trans('core.composer_reply_submit_button');
+    props.confirmExit = props.confirmExit || app.trans('core.composer_reply_discard_confirmation');
   }
 
   headerItems() {
@@ -75,7 +75,7 @@ export default class ReplyComposer extends ComposerBody {
           let alert;
           const viewButton = Button.component({
             className: 'Button Button--link',
-            children: app.trans('core.view'),
+            children: app.trans('core.composer_reply_view_button'),
             onclick: () => {
               m.route(app.route.post(post));
               app.alerts.dismiss(alert);
@@ -84,7 +84,7 @@ export default class ReplyComposer extends ComposerBody {
           app.alerts.show(
             alert = new Alert({
               type: 'success',
-              message: app.trans('core.reply_posted'),
+              message: app.trans('core.composer_reply_posted_message'),
               controls: [viewButton]
             })
           );

--- a/js/forum/src/components/ReplyPlaceholder.js
+++ b/js/forum/src/components/ReplyPlaceholder.js
@@ -44,7 +44,7 @@ export default class ReplyPlaceholder extends Component {
       <article className="Post ReplyPlaceholder" onclick={reply} onmousedown={triggerClick}>
         <header className="Post-header">
           {avatar(app.session.user, {className: 'PostUser-avatar'})}{' '}
-          {app.trans('core.write_a_reply')}
+          {app.trans('core.post_stream_reply_placeholder')}
         </header>
       </article>
     );

--- a/js/forum/src/components/Search.js
+++ b/js/forum/src/components/Search.js
@@ -83,7 +83,7 @@ export default class Search extends Component {
       })}>
         <div className="Search-input">
           <input className="FormControl"
-            placeholder={app.trans('core.search_forum')}
+            placeholder={app.trans('core.header_search_placeholder')}
             value={this.value()}
             oninput={m.withAttr('value', this.value)}
             onfocus={() => this.hasFocus = true}

--- a/js/forum/src/components/SessionDropdown.js
+++ b/js/forum/src/components/SessionDropdown.js
@@ -47,7 +47,7 @@ export default class SessionDropdown extends Dropdown {
     items.add('profile',
       LinkButton.component({
         icon: 'user',
-        children: app.trans('core.profile'),
+        children: app.trans('core.header_profile_button'),
         href: app.route.user(user)
       }),
       100
@@ -56,7 +56,7 @@ export default class SessionDropdown extends Dropdown {
     items.add('settings',
       LinkButton.component({
         icon: 'cog',
-        children: app.trans('core.settings'),
+        children: app.trans('core.header_settings_button'),
         href: app.route('settings')
       }),
       50
@@ -66,7 +66,7 @@ export default class SessionDropdown extends Dropdown {
       items.add('administration',
         LinkButton.component({
           icon: 'wrench',
-          children: app.trans('core.administration'),
+          children: app.trans('core.header_admin_button'),
           href: app.forum.attribute('baseUrl') + '/admin',
           target: '_blank',
           config: () => {}
@@ -80,7 +80,7 @@ export default class SessionDropdown extends Dropdown {
     items.add('logOut',
       Button.component({
         icon: 'sign-out',
-        children: app.trans('core.log_out'),
+        children: app.trans('core.header_log_out_button'),
         onclick: app.session.logout.bind(app.session)
       }),
       -100

--- a/js/forum/src/components/SettingsPage.js
+++ b/js/forum/src/components/SettingsPage.js
@@ -17,7 +17,7 @@ export default class SettingsPage extends UserPage {
     super(...args);
 
     this.show(app.session.user);
-    app.setTitle(app.trans('core.settings'));
+    app.setTitle(app.trans('core.settings_title'));
   }
 
   content() {
@@ -38,7 +38,7 @@ export default class SettingsPage extends UserPage {
 
     items.add('account',
       FieldSet.component({
-        label: app.trans('core.account'),
+        label: app.trans('core.settings_account_heading'),
         className: 'Settings-account',
         children: this.accountItems().toArray()
       })
@@ -46,7 +46,7 @@ export default class SettingsPage extends UserPage {
 
     items.add('notifications',
       FieldSet.component({
-        label: app.trans('core.notifications'),
+        label: app.trans('core.settings_notifications_heading'),
         className: 'Settings-notifications',
         children: [NotificationGrid.component({user: this.user})]
       })
@@ -54,7 +54,7 @@ export default class SettingsPage extends UserPage {
 
     items.add('privacy',
       FieldSet.component({
-        label: app.trans('core.privacy'),
+        label: app.trans('core.settings_privacy_heading'),
         className: 'Settings-privacy',
         children: this.privacyItems().toArray()
       })
@@ -73,7 +73,7 @@ export default class SettingsPage extends UserPage {
 
     items.add('changePassword',
       Button.component({
-        children: app.trans('core.change_password'),
+        children: app.trans('core.settings_change_password_button'),
         className: 'Button',
         onclick: () => app.modal.show(new ChangePasswordModal())
       })
@@ -81,7 +81,7 @@ export default class SettingsPage extends UserPage {
 
     items.add('changeEmail',
       Button.component({
-        children: app.trans('core.change_email'),
+        children: app.trans('core.settings_change_email_button'),
         className: 'Button',
         onclick: () => app.modal.show(new ChangeEmailModal())
       })
@@ -118,7 +118,7 @@ export default class SettingsPage extends UserPage {
 
     items.add('discloseOnline',
       Switch.component({
-        children: app.trans('core.disclose_online'),
+        children: app.trans('core.settings_privacy_disclose_online_label'),
         state: this.user.preferences().discloseOnline,
         onchange: (value, component) => {
           this.user.pushAttributes({lastSeenTime: null});

--- a/js/forum/src/components/SignUpModal.js
+++ b/js/forum/src/components/SignUpModal.js
@@ -52,7 +52,7 @@ export default class SignUpModal extends Modal {
   }
 
   title() {
-    return app.trans('core.sign_up');
+    return app.trans('core.sign_up_title');
   }
 
   content() {
@@ -72,14 +72,14 @@ export default class SignUpModal extends Modal {
 
       <div className="Form Form--centered">
         <div className="Form-group">
-          <input className="FormControl" name="username" placeholder={app.trans('core.username')}
+          <input className="FormControl" name="username" placeholder={app.trans('core.sign_up_username_placeholder')}
             value={this.username()}
             onchange={m.withAttr('value', this.username)}
             disabled={this.loading} />
         </div>
 
         <div className="Form-group">
-          <input className="FormControl" name="email" type="email" placeholder={app.trans('core.email')}
+          <input className="FormControl" name="email" type="email" placeholder={app.trans('core.sign_up_email_placeholder')}
             value={this.email()}
             onchange={m.withAttr('value', this.email)}
             disabled={this.loading || (this.props.token && this.props.email)} />
@@ -87,7 +87,7 @@ export default class SignUpModal extends Modal {
 
         {this.props.token ? '' : (
           <div className="Form-group">
-            <input className="FormControl" name="password" type="password" placeholder={app.trans('core.password')}
+            <input className="FormControl" name="password" type="password" placeholder={app.trans('core.sign_up_password_placeholder')}
               value={this.password()}
               onchange={m.withAttr('value', this.password)}
               disabled={this.loading} />
@@ -99,7 +99,7 @@ export default class SignUpModal extends Modal {
             className="Button Button--primary Button--block"
             type="submit"
             loading={this.loading}>
-            {app.trans('core.sign_up')}
+            {app.trans('core.sign_up_submit_button')}
           </Button>
         </div>
       </div>
@@ -119,13 +119,14 @@ export default class SignUpModal extends Modal {
           <div className="darkenBackground">
             <div className="container">
               {avatar(user)}
-              <h3>{app.trans('core.welcome_user', {user})}</h3>
+              <h3>{app.trans('core.sign_up_welcome_text', {user})}</h3>
 
-              <p>{app.trans('core.confirmation_email_sent', {email: <strong>{user.email()}</strong>})}</p>
+              <p>{app.trans('core.sign_up_confirmation_message', {email: <strong>{user.email()}</strong>})}</p>
 
               <p>
+                // Core Key Reorganization: This needs to be changed to a dismiss button!
                 <a href={`http://${emailProviderName}`} className="Button Button--primary" target="_blank">
-                  {app.trans('core.go_to', {location: emailProviderName})}
+                  {app.trans('core.sign_up_dismiss_button', {location: emailProviderName})}
                 </a>
               </p>
             </div>
@@ -140,8 +141,9 @@ export default class SignUpModal extends Modal {
   footer() {
     return [
       <p className="SignUpModal-logIn">
-        {app.trans('core.before_log_in_link')}{' '}
-        <a onclick={this.logIn.bind(this)}>{app.trans('core.log_in')}</a>
+        // Core Key Reorganization: Moved hardcoded space into preceding string.
+        {app.trans('core.sign_up_already_have_account_text')}
+        <a onclick={this.logIn.bind(this)}>{app.trans('core.sign_up_log_in_link')}</a>
       </p>
     ];
   }

--- a/js/forum/src/components/TerminalPost.js
+++ b/js/forum/src/components/TerminalPost.js
@@ -19,7 +19,8 @@ export default class TerminalPost extends Component {
 
     return (
       <span>
-        {app.trans('core.discussion_' + (lastPost ? 'replied' : 'started'), {
+        // Core Key Reorganization: Adjusted syntax for new key names 
+        {app.trans('core.discussion_list_' + (lastPost ? 'replied' : 'started') + '_text', {
           user,
           ago: humanTime(time)
         })}

--- a/js/forum/src/components/UserBio.js
+++ b/js/forum/src/components/UserBio.js
@@ -30,7 +30,7 @@ export default class UserBio extends Component {
     let content;
 
     if (this.editing) {
-      content = <textarea className="FormControl" placeholder={app.trans('core.bio_placeholder')} rows="3" value={user.bio()}/>;
+      content = <textarea className="FormControl" placeholder={app.trans('core.user_bio_placeholder')} rows="3" value={user.bio()}/>;
     } else {
       let subContent;
 
@@ -42,7 +42,7 @@ export default class UserBio extends Component {
         if (bioHtml) {
           subContent = m.trust(bioHtml);
         } else if (this.props.editable) {
-          subContent = <p className="UserBio-placeholder">{app.trans('core.bio_placeholder')}</p>;
+          subContent = <p className="UserBio-placeholder">{app.trans('core.user_bio_placeholder')}</p>;
         }
       }
 

--- a/js/forum/src/components/UserCard.js
+++ b/js/forum/src/components/UserCard.js
@@ -40,7 +40,7 @@ export default class UserCard extends Component {
               className: 'UserCard-controls App-primaryControl',
               menuClassName: 'Dropdown-menu--right',
               buttonClassName: this.props.controlsButtonClassName,
-              label: app.trans('core.controls'),
+              label: app.trans('core.user_controls_button'),
               icon: 'ellipsis-v'
             }) : ''}
 
@@ -95,13 +95,13 @@ export default class UserCard extends Component {
       items.add('lastSeen', (
         <span className={'UserCard-lastSeen' + (online ? ' online' : '')}>
           {online
-            ? [icon('circle'), ' ', app.trans('core.online')]
+            ? [icon('circle'), ' ', app.trans('core.user_online_text')]
             : [icon('clock-o'), ' ', humanTime(lastSeenTime)]}
         </span>
       ));
     }
 
-    items.add('joined', app.trans('core.joined', {ago: humanTime(user.joinTime())}));
+    items.add('joined', app.trans('core.user_joined_date_text', {ago: humanTime(user.joinTime())}));
 
     return items;
   }

--- a/js/forum/src/components/UserPage.js
+++ b/js/forum/src/components/UserPage.js
@@ -131,7 +131,7 @@ export default class UserPage extends Page {
     items.add('posts',
       LinkButton.component({
         href: app.route('user.posts', {username: user.username()}),
-        children: [app.trans('core.posts'), <span className="Button-badge">{user.commentsCount()}</span>],
+        children: [app.trans('core.user_posts_link'), <span className="Button-badge">{user.commentsCount()}</span>],
         icon: 'comment-o'
       })
     );
@@ -139,7 +139,7 @@ export default class UserPage extends Page {
     items.add('discussions',
       LinkButton.component({
         href: app.route('user.discussions', {username: user.username()}),
-        children: [app.trans('core.discussions'), <span className="Button-badge">{user.discussionsCount()}</span>],
+        children: [app.trans('core.user_discussions_link'), <span className="Button-badge">{user.discussionsCount()}</span>],
         icon: 'reorder'
       })
     );
@@ -149,7 +149,7 @@ export default class UserPage extends Page {
       items.add('settings',
         LinkButton.component({
           href: app.route('settings'),
-          children: app.trans('core.settings'),
+          children: app.trans('core.user_settings_link'),
           icon: 'cog'
         })
       );

--- a/js/forum/src/components/UsersSearchSource.js
+++ b/js/forum/src/components/UsersSearchSource.js
@@ -22,7 +22,7 @@ export default class UsersSearchResults {
     if (!results.length) return '';
 
     return [
-      <li className="Dropdown-header">{app.trans('core.users')}</li>,
+      <li className="Dropdown-header">{app.trans('core.search_users_heading')}</li>,
       results.map(user => (
         <li className="UserSearchResult" data-index={'users' + user.id()}>
           <a href={app.route.user(user)} config={m.route}>

--- a/js/forum/src/utils/DiscussionControls.js
+++ b/js/forum/src/utils/DiscussionControls.js
@@ -55,14 +55,15 @@ export default {
         !app.session.user || discussion.canReply()
           ? Button.component({
             icon: 'reply',
-            children: app.session.user ? app.trans('core.reply') : app.trans('core.log_in_to_reply'),
+            // Core Key Reorganization: Combined two app.trans calls into one using Toby's slightly slicker way.
+            children: app.trans(app.session.user ? 'core.discussion_controls_reply_button' : 'core.discussion_controls_log_in_to_reply_button'),
             onclick: this.replyAction.bind(discussion, true, false)
           })
           : Button.component({
             icon: 'reply',
-            children: app.trans('core.cannot_reply'),
+            children: app.trans('core.discussion_controls_cannot_reply_button'),
             className: 'disabled',
-            title: app.trans('core.cannot_reply_help')
+            title: app.trans('core.discussion_controls_cannot_reply_text')
           })
       );
     }
@@ -85,7 +86,7 @@ export default {
     if (discussion.canRename()) {
       items.add('rename', Button.component({
         icon: 'pencil',
-        children: app.trans('core.rename'),
+        children: app.trans('core.discussion_controls_rename_button'),
         onclick: this.renameAction.bind(discussion)
       }));
     }
@@ -109,21 +110,21 @@ export default {
       if (discussion.canHide()) {
         items.add('hide', Button.component({
           icon: 'trash-o',
-          children: app.trans('core.delete'),
+          children: app.trans('core.discussion_controls_delete_button'),
           onclick: this.hideAction.bind(discussion)
         }));
       }
     } else if (discussion.canDelete()) {
       items.add('restore', Button.component({
         icon: 'reply',
-        children: app.trans('core.restore'),
+        children: app.trans('core.discussion_controls_restore_button'),
         onclick: this.restoreAction.bind(discussion),
         disabled: discussion.commentsCount() === 0
       }));
 
       items.add('delete', Button.component({
         icon: 'times',
-        children: app.trans('core.delete_forever'),
+        children: app.trans('core.discussion_controls_delete_forever_button'),
         onclick: this.deleteAction.bind(discussion)
       }));
     }
@@ -216,7 +217,7 @@ export default {
    * @return {Promise}
    */
   deleteAction() {
-    if (confirm(extractText(app.trans('core.confirm_delete_discussion')))) {
+    if (confirm(extractText(app.trans('core.discussion_controls_delete_confirmation')))) {
       // If there is a discussion list in the cache, remove this discussion.
       if (app.cache.discussionList) {
         app.cache.discussionList.removeDiscussion(this);
@@ -239,7 +240,7 @@ export default {
    */
   renameAction() {
     const currentTitle = this.title();
-    const title = prompt(extractText(app.trans('core.prompt_rename_discussion')), currentTitle);
+    const title = prompt(extractText(app.trans('core.discussion_controls_rename_text')), currentTitle);
 
     // If the title is different to what it was before, then save it. After the
     // save has completed, update the post stream as there will be a new post

--- a/js/forum/src/utils/PostControls.js
+++ b/js/forum/src/utils/PostControls.js
@@ -60,7 +60,7 @@ export default {
       if (!post.isHidden()) {
         items.add('edit', Button.component({
           icon: 'pencil',
-          children: app.trans('core.edit'),
+          children: app.trans('core.post_controls_edit_button'),
           onclick: this.editAction.bind(post)
         }));
       }
@@ -85,7 +85,7 @@ export default {
       if (post.canEdit()) {
         items.add('hide', Button.component({
           icon: 'trash-o',
-          children: app.trans('core.delete'),
+          children: app.trans('core.post_controls_delete_button'),
           onclick: this.hideAction.bind(post)
         }));
       }
@@ -93,14 +93,14 @@ export default {
       if (post.canEdit()) {
         items.add('restore', Button.component({
           icon: 'reply',
-          children: app.trans('core.restore'),
+          children: app.trans('core.post_controls_restore_button'),
           onclick: this.restoreAction.bind(post)
         }));
       }
       if (post.canDelete() && post.number() !== 1) {
         items.add('delete', Button.component({
           icon: 'times',
-          children: app.trans('core.delete_forever'),
+          children: app.trans('core.post_controls_delete_forever_button'),
           onclick: this.deleteAction.bind(post)
         }));
       }

--- a/js/forum/src/utils/UserControls.js
+++ b/js/forum/src/utils/UserControls.js
@@ -60,7 +60,7 @@ export default {
     if (user.canEdit()) {
       items.add('edit', Button.component({
         icon: 'pencil',
-        children: app.trans('core.edit'),
+        children: app.trans('core.user_controls_edit_button'),
         onclick: this.editAction.bind(user)
       }));
     }
@@ -83,7 +83,7 @@ export default {
     if (user.id() !== '1' && user.canDelete()) {
       items.add('delete', Button.component({
         icon: 'times',
-        children: app.trans('core.delete'),
+        children: app.trans('core.user_controls_delete_button'),
         onclick: this.deleteAction.bind(user)
       }));
     }

--- a/js/lib/helpers/username.js
+++ b/js/lib/helpers/username.js
@@ -6,7 +6,8 @@
  * @return {Object}
  */
 export default function username(user) {
-  const name = (user && user.username()) || app.trans('deleted');
+  // Core Key Reorganization: Added core namespacing to the key.
+  const name = (user && user.username()) || app.trans('core.deleted_username');
 
   return <span className="username">{name}</span>;
 }

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -1,43 +1,222 @@
 core:
-  account: Account
-  administration: Administration
-  alert: Alert
-  all_discussions: All Discussions
-  before_log_in_link: Already have an account?
-  before_sign_up_link: Don't have an account?
-  bio_placeholder: Write something about yourself
-  cannot_reply: Can't Reply
-  cannot_reply_help: You don't have permission to reply to this discussion.
+
+##
+# UNIQUE KEYS - The following keys are used in only one location each.
+##
+
+  # These strings are used in the Change Email modal dialog.
+  change_email_confirmation_message: => core.confirmation_email_sent
+  change_email_dismiss_button: => core.okay
+  change_email_submit_button: => core.save_changes
+  change_email_title: => core.change_email
+
+  # These strings are used in the Change Password modal dialog.
+  change_password_send_button: Send Password Reset Email
+  change_password_text: Click the button below and check your email for a link to change your password.
+  change_password_title: => core.change_password
+
+  # These strings are used by the Composer controls.
+  composer_close_tooltip: Close
+  composer_exit_full_screen_tooltip: Exit Full Screen
+  composer_full_screen_tooltip: Full Screen
+  composer_minimize_tooltip: Minimize
+
+  # These strings are used by the Composer when starting a discussion.
+  composer_discussion_body_placeholder: Write a Post...
+  composer_discussion_discard_confirmation: You have not posted your discussion. Do you wish to discard it?
+  composer_discussion_submit_button: Post Discussion
+  composer_discussion_title_placeholder: Discussion Title
+
+  # These strings are used by the Composer when editing a post.
+  composer_edit_discard_confirmation: You have not saved your changes. Do you wish to discard them?
+  composer_edit_post_link: "Post #{number} in {discussion}"
+  composer_edit_submit_button: => core.save_changes
+
+  # These strings are used by the Composer when replying to a discussion.
+  composer_reply_body_placeholder: => core.write_a_reply
+  composer_reply_discard_confirmation: You have not posted your reply. Do you wish to discard it?
+  composer_reply_posted_message: Your reply was posted.
+  composer_reply_submit_button: Post Reply
+  composer_reply_view_button: View
+
+  # These strings are used by the discussion control buttons.
+  discussion_controls_cannot_reply_button: Can't Reply
+  discussion_controls_cannot_reply_text: You don't have permission to reply to this discussion.
+  discussion_controls_delete_button: => core.delete
+  discussion_controls_delete_confirmation: Are you sure you want to delete this discussion?
+  discussion_controls_delete_forever_button: => core.delete_forever
+  discussion_controls_log_in_to_reply_button: Log In to Reply
+  discussion_controls_rename_button: Rename
+  discussion_controls_rename_text: Enter a new title for this discussion:
+  discussion_controls_reply_button: Reply
+  discussion_controls_restore_button: => core.restore
+
+  # These strings are used in the discussion list.
+  discussion_list_load_more_button: => core.load_more
+  discussion_list_mark_as_read_tooltip: Mark as Read
+  discussion_list_replied_text: "Last reply {ago} by {username}"
+  discussion_list_started_text: "Started {ago} by {username}"
+
+  # These strings are used in the Edit User modal dialog (moderator function).
+  edit_user_email_label: => core.email
+  edit_user_password_label: => core.password
+  edit_user_submit_button: => core.save_changes
+  edit_user_username_label: => core.username
+
+  # These strings are used in the Forgot Password modal dialog.
+  forgot_password_dismiss_button: => core.okay
+  forgot_password_email_placeholder: => core.email
+  forgot_password_email_sent_message: We've sent you an email containing a link to reset your password. Check your spam folder if you don't receive it within the next minute or two.
+  forgot_password_submit_button: Recover Password
+  forgot_password_text: Enter your email address and we will send you a link to reset your password.
+  forgot_password_title: Forgot Password
+
+  # These strings are used in the header and session dropdown menu.
+  header_admin_button: Administration
+  header_log_in_link: => core.log_in
+  header_log_out_button: Log Out
+  header_profile_button: Profile
+  header_search_placeholder: Search Forum
+  header_settings_button: => core.settings
+  header_sign_up_link: => core.sign_up
+
+  # These strings are used on the index page, peripheral to the discussion list.
+  index_all_discussions_link: All Discussions
+  index_cannot_start_discussion_button: "Can't Start Discussion"
+  index_mark_all_as_read_tooltip: => core.mark_all_as_read
+  index_refresh_tooltip: Refresh
+  index_start_discussion_button: Start a Discussion
+
+  # These strings are used by the sorting control above the discussion list.
+  index_sort_latest_button: Latest
+  index_sort_newest_button: Newest
+  index_sort_oldest_button: Oldest
+  index_sort_relevance_button: Relevance
+  index_sort_top_button: Top
+
+  # These strings are used in the Log In modal dialog.
+  log_in_confirmation_required_message: "You need to confirm your email before you can log in. We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
+  log_in_forgot_password_link: Forgot password?
+  log_in_invalid_login_message: Your login details were incorrect.
+  log_in_no_account_text: "Don't have an account? "
+  log_in_password_placeholder: => core.password
+  log_in_sign_up_link: => core.sign_up
+  log_in_submit_button: => core.log_in
+  log_in_title: => core.log_in
+  log_in_username_or_email_placeholder: Username or Email
+
+  # These strings are used by the Notifications dropdown, a.k.a. "the bell".
+  notifications_discussion_renamed_text: "{username} changed the title"
+  notifications_empty_text: No Notifications
+  notifications_mark_all_as_read_tooltip: => core.mark_all_as_read
+  notifications_title: => core.notifications
+  notifications_tooltip: => core.notifications
+
+  # These strings are used by tooltips displayed for individual posts.
+  post_edited_tooltip: "{username} edited {ago}"
+  post_number_tooltip: "Post #{number}"
+
+  # These strings are used by the post control buttons.
+  post_controls_delete_button: => core.delete
+  post_controls_delete_forever_button: => core.delete_forever
+  post_controls_edit_button: => core.edit
+  post_controls_restore_button: => core.restore
+
+  # These strings are used in the scrubber to the right of the post stream.
+  post_scrubber_now_link: Now
+  post_scrubber_original_post_link: Original Post
+  post_scrubber_unread_text: "{count} unread"
+  post_scrubber_viewing_text:
+    one: "{index} of {count} post"
+    other: "{index} of {count} posts"
+
+  # These strings are displayed between posts in the post stream.
+  post_stream_discussion_renamed_text: "{username} changed the title from {old} to {new}."
+  post_stream_reply_placeholder: => core.write_a_reply
+  post_stream_time_lapsed_text: "{period} later"
+
+  # These strings are used by the search results dropdown list.
+  search_all_discussions_button: 'Search all discussions for "{query}"'
+  search_discussions_heading: => core.discussions
+  search_users_heading: Users
+
+  # These strings are used in the Settings page.
+  settings_account_heading: Account
+  settings_change_email_button: => core.change_email
+  settings_change_password_button: => core.change_password
+  settings_notifications_heading: => core.notifications
+  settings_privacy_disclose_online_label: Allow others to see when I am online
+  settings_privacy_heading: Privacy
+  settings_title: => core.settings
+
+  # These strings are used in the Notifications grid on the Settings page.
+  settings_notify_by_email_heading: => core.email
+  settings_notify_by_web_heading: Web
+  settings_notify_discussion_renamed_label: Someone renames a discussion I started
+
+  # These strings are used in the Sign Up modal dialog.
+  sign_up_already_have_account_text: "Already have an account? "
+  sign_up_confirmation_message: => core.confirmation_email_sent
+  sign_up_email_placeholder: => core.email
+  sign_up_dismiss_button: => core.okay
+  sign_up_log_in_link: => core.log_in
+  sign_up_password_placeholder: => core.password
+  sign_up_submit_button: => core.sign_up
+  sign_up_title: => core.sign_up
+  sign_up_username_placeholder: => core.username
+  sign_up_welcome_text: "Welcome, {username}!"
+
+  # These strings are used in the user profile page and profile popup.
+  user_bio_placeholder: Write something about yourself
+  user_discussions_link: => core.discussions
+  user_joined_date_text: "Joined {ago}"
+  user_online_text: Online
+  user_posts_load_more_button: => core.load_more
+  user_posts_link: Posts
+  user_settings_link: => core.settings
+
+  # These strings are used to control the avatar in the user profile page.
+  user_avatar_remove_button: Remove
+  user_avatar_upload_button: Upload
+
+  # These strings are found on the user profile page (moderator function).
+  user_controls_button: Controls
+  user_controls_delete_button: => core.delete
+  user_controls_edit_button: => core.edit
+
+##
+# REUSED STRINGS - The following keys are referenced by two or more unique keys.
+##
+
   change_email: Change Email
   change_password: Change Password
-  change_password_help: Click the button below and check your email for a link to change your password.
-  close: Close
-  confirm_delete_discussion: Are you sure you want to delete this discussion?
-  confirm_discard_discussion: You have not posted your discussion. Do you wish to discard it?
-  confirm_discard_edit: You have not saved your changes. Do you wish to discard them?
-  confirm_discard_reply: You have not posted your reply. Do you wish to discard it?
   confirmation_email_sent: "We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
-  controls: Controls
   delete: Delete
   delete_forever: Delete Forever
-  deleted: "[deleted]"
-  disclose_online: Allow others to see when I am online
-  discussion_renamed_post: "{username} changed the title from {old} to {new}."
-  discussion_renamed_notification: "{username} changed the title"
-  discussion_replied: "Last reply {ago} by {username}"
-  discussion_started: "Started {ago} by {username}"
-  discussion_title: Discussion Title
   discussions: Discussions
   edit: Edit
-  editing_post: "Post #{number} in {discussion}"
   email: Email
-  email_confirmation_required: "You need to confirm your email before you can log in. We've sent a confirmation email to {email}. If it doesn't arrive soon, check your spam folder."
-  exit_full_screen: Exit Full Screen
-  forgot_password: Forgot Password
-  forgot_password_help: Enter your email address and we will send you a link to reset your password.
-  forgot_password_link: Forgot password?
-  full_screen: Full Screen
-  go_to: "Go to {location}"
+  load_more: Load More
+  log_in: Log In
+  mark_all_as_read: Mark All as Read
+  notifications: Notifications
+  okay: OK
+  password: Password
+  restore: Restore
+  save_changes: Save Changes
+  settings: Settings
+  sign_up: Sign Up
+  username: Username
+  write_a_reply: Write a Reply...
+
+##
+# GLOBAL STRINGS - Keys in this section are used globally (or generated automatically).
+##
+
+  # This string replaces a deleted username:
+  deleted_username: "[deleted]"
+
+  # The following keys are generated from group names:
   group_admin: Admin
   group_admins: Admins
   group_guest: Guest
@@ -46,61 +225,6 @@ core:
   group_members: Members
   group_mod: Mod
   group_mods: Mods
-  invalid_login: Your login details were incorrect.
-  joined: "Joined {ago}"
-  load_more: Load More
-  log_in: Log In
-  log_in_to_reply: Log In to Reply
-  log_out: Log Out
-  mark_all_as_read: Mark All as Read
-  mark_as_read: Mark as Read
-  minimize: Minimize
-  no_notifications: No Notifications
-  notifications: Notifications
-  notify_discussion_renamed: Someone renames a discussion I started
-  now: Now
-  online: Online
-  original_post: Original Post
-  password: Password
-  password_reset_email_sent: We've sent you an email containing a link to reset your password. Check your spam folder if you don't receive it within the next minute or two.
-  period_later: "{period} later"
-  post_discussion: Post Discussion
-  post_edited: "{username} edited {ago}"
-  post_number: "Post #{number}"
-  post_reply: Post Reply
-  posts: Posts
+
+  # This string is currently unused:
   powered_by_flarum: Powered by Flarum
-  privacy: Privacy
-  profile: Profile
-  prompt_rename_discussion: Enter a new title for this discussion:
-  recover_password: Recover Password
-  refresh: Refresh
-  remove: Remove
-  rename: Rename
-  reply: Reply
-  reply_posted: Your reply was posted.
-  restore: Restore
-  save_changes: Save Changes
-  search_all_discussions: 'Search all discussions for "{query}"'
-  search_forum: Search Forum
-  send_password_reset_email: Send Password Reset Email
-  settings: Settings
-  sign_up: Sign Up
-  sort_latest: Latest
-  sort_newest: Newest
-  sort_oldest: Oldest
-  sort_relevance: Relevance
-  sort_top: Top
-  start_a_discussion: Start a Discussion
-  unread_posts: "{count} unread"
-  upload: Upload
-  username: Username
-  username_or_email: Username or Email
-  users: Users
-  view: View
-  viewing_posts:
-    one: "{index} of {count} post"
-    other: "{index} of {count} posts"
-  welcome_user: "Welcome, {username}!"
-  write_a_post: Write a Post...
-  write_a_reply: Write a Reply...


### PR DESCRIPTION
Improved consistency for existing core translation key names

See flarum/core#265
- Requires replacement of “Go to” buttons with dismiss buttons
- Requires compiler to resolve key name references